### PR TITLE
docs: Fix & clean markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,45 +7,12 @@ Plugin posiada tagi (na zdjęciach nie widać bo jak je robiłem to jeszcze nie 
 
 No cóż, pozostało mi jedynie pokazanie Wam zdjęć :P Miłego oglądania.
 
-![alt tag](http://www.e-gify.pl/gify/dla_stron_i_blogow/linie/linie70.gif)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/n7/7k/gl/mplbcj.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/zs/ls/pb/qrpyfn.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/sv/um/09/pfqste.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/az/lg/c2/c9p7ji.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/ij/8a/3h/viad5p.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/n3/9l/wv/s1mycm.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/zt/8g/2k/uf2miv.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/s3/k1/zc/e09l2q.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/o7/qd/7x/0enbuc.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/95/9q/j2/wc5d9q.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/p2/76/kn/lqs3ai.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/r5/94/dh/g5bxj4.jpg)
-
-![alt tag](http://screenshu.com/static/uploads/temporary/2b/39/2b/asda3w.jpg)
-
-
-
-![alt tag](http://www.e-gify.pl/gify/dla_stron_i_blogow/linie/linie70.gif)
-
-
 ## POBIERANIE/SKAN
 http://kavz.za.pl/qGuilds
 
 (link do strony pobierania wraz ze spolszczeniem)
 
-![alt tag](http://www.e-gify.pl/gify/dla_stron_i_blogow/linie/linie70.gif)
+---
 
 ## DOTACJE
 
@@ -54,12 +21,11 @@ http://kavz.za.pl/qGuilds
 ,,Brak tekstu''
 
 
-
-![alt tag](http://www.e-gify.pl/gify/dla_stron_i_blogow/linie/linie70.gif)
+---
 
 ## ZBIÓR INFORMACJI  
 
-###*>  UPRAWINENIA  <*
+### *>  UPRAWINENIA  <*
 -  qguilds.ally  
 -  qguilds.broadcast  
 -  qguilds.create  
@@ -85,7 +51,7 @@ http://kavz.za.pl/qGuilds
 -  qguilds.admin.player  
 -  qguilds.admin.reload  
 
-###*>  WYMAGANIA SPRZĘTOWE  <*
+### *>  WYMAGANIA SPRZĘTOWE  <*
 
 ProtocolLib 1.8.X  (konkretny build)
 
@@ -97,7 +63,7 @@ Silnik Spigot 1.8.6  (konkretny build)
 https://mega.co.nz/#!OcEy3TaD!Qo7JPkCPmi-iVcYN8ExQmcNlU5appxntGCNDACWITGQ
 https://www.virustotal.com/pl/file/efb01531ae16810e5e4b6e1ab6e4839df8e5f5d51001a6aad3b39850c1147e36/analysis/
 
-![alt tag](http://www.e-gify.pl/gify/dla_stron_i_blogow/linie/linie70.gif)
+---
 
 
 Pozdrawiam i życzę miłego dnia.


### PR DESCRIPTION
Usunąłem linki do screenshotów, które już są niedostępne i zmieniłem animowane linie na zwykłe horyzontalne (żeby było kompatybilne z czytnikami na mobilne)